### PR TITLE
full fletched Makefile for kernel with features:

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -1,3 +1,36 @@
 obj-m := bcm2835_spi_display.o
 
 CFLAGS_bcm2835_spi_display.o := -O3 -std=gnu99 -Wno-declaration-after-statement -DKERNEL_MODULE=1 -DILI9341=1 -DADAFRUIT_ILI9341_PITFT=1 -DSPI_BUS_CLOCK_DIVISOR=48 
+
+KDIR ?= /lib/modules/$(shell uname -r)
+
+all $(obj-m:%.o=%.ko):
+	$(MAKE) -C "$(KDIR)/build" M="$(CURDIR)" modules
+
+install: stop $(obj-m:%.o=%.ko)
+	$(MAKE) -C "$(KDIR)/build" M="$(CURDIR)" modules_install
+	@depmod -a
+
+uninstall: stop
+	@rm -vf -- "$(KDIR)/extra/$(obj-m:%.o=%.ko)" 
+	@depmod -a
+
+start: 
+	@modprobe -v $(obj-m:%.o=%)
+
+stop:
+	@pgrep "fbcp-ili9341.*" && pkill "fbcp-ili9341.*" || true
+	@pgrep "fbcp-ili9341.*" && sleep 5 && pkill -KILL "fbcp-ili9341.*" || true
+	@modprobe -vr $(obj-m:%.o=%)
+
+status:
+	@modinfo $(obj-m:%.o=%)
+	@echo loaded:
+	@lsmod | grep $(obj-m:%.o=%) || echo not loaded
+
+debug: $(obj-m:%.o=%.ko)
+	@objdump -dS $< > $(obj-m:%.o=%.S)
+
+clean:
+	$(MAKE) -C "$(KDIR)/build" M="$(CURDIR)" clean
+	@rm -rf -- $(obj-m:%.o=%.S)

--- a/kernel/build_kernel_module.sh
+++ b/kernel/build_kernel_module.sh
@@ -1,6 +1,5 @@
-sudo ./stop_kernel_module.sh
-sudo make VERBOSE=1 -C /lib/modules/$(uname -r)/build M=$(pwd) -I/usr/include/ modules
+sudo make
 
 #For debugging: generate disassembly output:
-#objdump -dS bcm2835_spi_display.ko > bcm2835_spi_display.S
+#make debug
 

--- a/kernel/start_kernel_module.sh
+++ b/kernel/start_kernel_module.sh
@@ -1,3 +1,3 @@
 echo Starting kernel module bcm2835_spi_display.ko
-sudo insmod bcm2835_spi_display.ko
+sudo make install start
 

--- a/kernel/stop_kernel_module.sh
+++ b/kernel/stop_kernel_module.sh
@@ -1,10 +1,3 @@
-# Kill user space driver program first if it happens to be running, because otherwise shutting down the kernel
-# module would crash the system if the userland program was still accessing it.
-echo Killing existing instances of user space driver program fbcp-ili9341
-sudo pkill fbcp-ili9341
-sudo pkill fbcp-ili9341-stable
-
-# Now safe to tear down the module
 echo Stopping kernel module bcm2835_spi_display.ko
-sudo rmmod bcm2835_spi_display.ko
+sudo make stop
 


### PR DESCRIPTION
* make - builds the kernel module
* make install - installs the kernel module
* make uninstall - uninstalls the kernel module
* make start - loads the module
* make stop - stops fbcp-ili9341 process and unloads the module
* make status - shows module info and if loaded in kernel
* make debug - generates disassembly output for debugging
* make clean - remove all files generates by this Makefile