### PR TITLE
Ili9486 touch support

### DIFF
--- a/ili9486.cpp
+++ b/ili9486.cpp
@@ -53,8 +53,8 @@ void InitILI9486()
 #endif
 
   // For sanity, start with both Chip selects high to ensure that the display will see a high->low enable transition when we start.
-  SET_GPIO(GPIO_SPI0_CE0); // Disable Touch
-  SET_GPIO(GPIO_SPI0_CE1); // Disable Display
+  SET_GPIO(GPIO_SPI0_CE1); // Disable Touch
+  SET_GPIO(GPIO_SPI0_CE0); // Disable Display
   usleep(1000);
 
   // Do the initialization with a very low SPI bus speed, so that it will succeed even if the bus speed chosen by the user is too high.
@@ -63,14 +63,14 @@ void InitILI9486()
 
   BEGIN_SPI_COMMUNICATION();
   {
-    CLEAR_GPIO(GPIO_SPI0_CE0); // Enable Touch
-    CLEAR_GPIO(GPIO_SPI0_CE1); // Enable Display
+    CLEAR_GPIO(GPIO_SPI0_CE1); // Enable Touch
+    CLEAR_GPIO(GPIO_SPI0_CE0); // Enable Display
 
     BEGIN_SPI_COMMUNICATION();
 
     usleep(25*1000);
 
-    SET_GPIO(GPIO_SPI0_CE0); // Disable Touch
+    SET_GPIO(GPIO_SPI0_CE1); // Disable Touch
     usleep(25*1000);
 
 #ifdef DISPLAY_SPI_BUS_IS_16BITS_WIDE

--- a/ili9486.cpp
+++ b/ili9486.cpp
@@ -18,8 +18,8 @@ static int loop = 0;
 void ChipSelectHigh()
 {
   WAIT_SPI_FINISHED();
-  SET_GPIO(GPIO_SPI0_CE1); // Disable Display
-  CLEAR_GPIO(GPIO_SPI0_CE0); // Enable Touch
+  SET_GPIO(GPIO_SPI0_CE0); // Disable Display
+  CLEAR_GPIO(GPIO_SPI0_CE1); // Enable Touch
   __sync_synchronize();
     if(loop++ % LOOP_INTERVAL == 0) {
         touch.read_touchscreen(true);
@@ -29,8 +29,8 @@ void ChipSelectHigh()
 	touch.read_touchscreen(false);
       __sync_synchronize();
   }
-  SET_GPIO(GPIO_SPI0_CE0); // Disable Touch
-  CLEAR_GPIO(GPIO_SPI0_CE1); // Enable Display
+  SET_GPIO(GPIO_SPI0_CE1); // Disable Touch
+  CLEAR_GPIO(GPIO_SPI0_CE0); // Enable Display
   __sync_synchronize();
 }
 

--- a/ili9486.h
+++ b/ili9486.h
@@ -21,5 +21,9 @@
 // ILI9486 does not behave well if one sends partial commands, but must finish each command or the command does not apply
 #define MUST_SEND_FULL_CURSOR_WINDOW
 
+// needs the Touch and Display CS lines pumped for each 32-bit word that is written, or otherwise it does not process bytes on the bus. (it does send
+// return bytes back on the MISO line though even without this, so it does at least do something even without this, but nothing would show up on the screen if this pumping is not done)
+#define CHIP_SELECT_LINE_NEEDS_REFRESHING_EACH_32BITS_WRITTEN
+
 void InitILI9486(void);
 #define InitSPIDisplay InitILI9486

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -1,3 +1,3 @@
 obj-m := bcm2835_spi_display.o
 
-CFLAGS_bcm2835_spi_display.o := -O3 -std=gnu99 -Wno-declaration-after-statement -DKERNEL_MODULE=1 -DILI9341=1 -DADAFRUIT_ILI9341_PITFT=1 -DSPI_BUS_CLOCK_DIVISOR=48 
+CFLAGS_bcm2835_spi_display.o := -O3 -std=gnu99 -Wno-declaration-after-statement -DKERNEL_MODULE=1 -DILI9486=1 -DWAVESHARE35B_ILI9486=1 -DSPI_BUS_CLOCK_DIVISOR=48 

--- a/spi.h
+++ b/spi.h
@@ -67,3 +67,4 @@ extern double spiUsecsPerByte;
 
 extern int mem_fd;
 
+extern volatile void *bcm2835;

--- a/spi.h
+++ b/spi.h
@@ -75,3 +75,45 @@ extern volatile void *bcm2835;
 // even a single full frame of data, but such small buffers can cause performance issues from threads starving.
 #define SHARED_MEMORY_SIZE (DISPLAY_DRAWABLE_WIDTH*DISPLAY_DRAWABLE_HEIGHT*SPI_BYTESPERPIXEL*3)
 #define SPI_QUEUE_SIZE (SHARED_MEMORY_SIZE - sizeof(SharedMemory))
+
+typedef struct SPIRegisterFile
+{
+  uint32_t cs;   // SPI Master Control and Status register
+  uint32_t fifo; // SPI Master TX and RX FIFOs
+  uint32_t clk;  // SPI Master Clock Divider
+  uint32_t dlen; // SPI Master Number of DMA Bytes to Write
+} SPIRegisterFile;
+extern volatile SPIRegisterFile *spi;
+
+typedef struct __attribute__((packed)) SPITask
+{
+  uint32_t size; // Size, including both 8-bit and 9-bit tasks
+#ifdef SPI_3WIRE_PROTOCOL
+  uint32_t sizeExpandedTaskWithPadding; // Size of the expanded 9-bit/32-bit task. The expanded task starts at address spiTask->data + spiTask->size - spiTask->sizeExpandedTaskWithPadding;
+#endif
+#ifdef SPI_32BIT_COMMANDS
+  uint32_t cmd;
+#else
+  uint8_t cmd;
+#endif
+  uint32_t dmaSpiHeader;
+#ifdef OFFLOAD_PIXEL_COPY_TO_DMA_CPP
+  uint8_t *fb;
+  uint8_t *prevFb;
+  uint16_t width;
+#endif
+  uint8_t data[]; // Contains both 8-bit and 9-bit tasks back to back, 8-bit first, then 9-bit.
+
+#ifdef SPI_3WIRE_PROTOCOL
+  inline uint8_t *PayloadStart() { return data + (size - sizeExpandedTaskWithPadding); }
+  inline uint8_t *PayloadEnd() { return data + (size - SPI_9BIT_TASK_PADDING_BYTES); }
+  inline uint32_t PayloadSize() const { return sizeExpandedTaskWithPadding - SPI_9BIT_TASK_PADDING_BYTES; }
+  inline uint32_t *DmaSpiHeaderAddress() { return (uint32_t*)(PayloadStart()-4); }
+#else
+  inline uint8_t *PayloadStart() { return data; }
+  inline uint8_t *PayloadEnd() { return data + size; }
+  inline uint32_t PayloadSize() const { return size; }
+  inline uint32_t *DmaSpiHeaderAddress() { return &dmaSpiHeader; }
+#endif
+
+} SPITask;

--- a/spi.h
+++ b/spi.h
@@ -76,6 +76,7 @@ extern volatile void *bcm2835;
 #define SHARED_MEMORY_SIZE (DISPLAY_DRAWABLE_WIDTH*DISPLAY_DRAWABLE_HEIGHT*SPI_BYTESPERPIXEL*3)
 #define SPI_QUEUE_SIZE (SHARED_MEMORY_SIZE - sizeof(SharedMemory))
 
+#ifndef KERNEL_MODULE
 typedef struct SPIRegisterFile
 {
   uint32_t cs;   // SPI Master Control and Status register
@@ -119,3 +120,4 @@ typedef struct __attribute__((packed)) SPITask
 } SPITask;
 
 void DumpSPICS(uint32_t reg);
+#endif

--- a/spi.h
+++ b/spi.h
@@ -117,3 +117,5 @@ typedef struct __attribute__((packed)) SPITask
 #endif
 
 } SPITask;
+
+void DumpSPICS(uint32_t reg);

--- a/spi.h
+++ b/spi.h
@@ -68,3 +68,10 @@ extern double spiUsecsPerByte;
 extern int mem_fd;
 
 extern volatile void *bcm2835;
+
+// Defines the size of the SPI task memory buffer in bytes. This memory buffer can contain two frames worth of tasks at maximum,
+// so for best performance, should be at least ~DISPLAY_WIDTH*DISPLAY_HEIGHT*BYTES_PER_PIXEL*2 bytes in size, plus some small
+// amount for structuring each SPITask command. Technically this can be something very small, like 4096b, and not need to contain
+// even a single full frame of data, but such small buffers can cause performance issues from threads starving.
+#define SHARED_MEMORY_SIZE (DISPLAY_DRAWABLE_WIDTH*DISPLAY_DRAWABLE_HEIGHT*SPI_BYTESPERPIXEL*3)
+#define SPI_QUEUE_SIZE (SHARED_MEMORY_SIZE - sizeof(SharedMemory))

--- a/spi_kernel.h
+++ b/spi_kernel.h
@@ -2,6 +2,7 @@
 
 #include "dma.h"
 #include "spi.h"
+#include "display.h"
 #include "tick.h"
 
 //#include <inttypes.h>

--- a/spi_kernel.h
+++ b/spi_kernel.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "dma.h"
 #include "spi.h"
 #include "tick.h"
 

--- a/spi_kernel.h
+++ b/spi_kernel.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "spi.h"
+#include "tick.h"
 
 //#include <inttypes.h>
 //#include <config/sysfs/syscall.h>

--- a/spi_kernel.h
+++ b/spi_kernel.h
@@ -9,3 +9,4 @@
 #ifndef USE_DMA_TRANSFERS
 #define VIRT_TO_BUS(ptr) ((uintptr_t)(ptr) | 0xC0000000U)
 #endif
+

--- a/spi_kernel.h
+++ b/spi_kernel.h
@@ -4,4 +4,6 @@
 
 //#include <inttypes.h>
 //#include <config/sysfs/syscall.h>
+#ifndef USE_DMA_TRANSFERS
 #define VIRT_TO_BUS(ptr) ((uintptr_t)(ptr) | 0xC0000000U)
+#endif

--- a/spi_user.h
+++ b/spi_user.h
@@ -34,13 +34,6 @@ typedef struct SPIRegisterFile
 } SPIRegisterFile;
 extern volatile SPIRegisterFile *spi;
 
-// Defines the size of the SPI task memory buffer in bytes. This memory buffer can contain two frames worth of tasks at maximum,
-// so for best performance, should be at least ~DISPLAY_WIDTH*DISPLAY_HEIGHT*BYTES_PER_PIXEL*2 bytes in size, plus some small
-// amount for structuring each SPITask command. Technically this can be something very small, like 4096b, and not need to contain
-// even a single full frame of data, but such small buffers can cause performance issues from threads starving.
-#define SHARED_MEMORY_SIZE (DISPLAY_DRAWABLE_WIDTH*DISPLAY_DRAWABLE_HEIGHT*SPI_BYTESPERPIXEL*3)
-#define SPI_QUEUE_SIZE (SHARED_MEMORY_SIZE - sizeof(SharedMemory))
-
 #if defined(SPI_3WIRE_DATA_COMMAND_FRAMING_BITS) && SPI_3WIRE_DATA_COMMAND_FRAMING_BITS == 1
 // Need a byte of padding for 8-bit -> 9-bit expansion for performance
 #define SPI_9BIT_TASK_PADDING_BYTES 1

--- a/spi_user.h
+++ b/spi_user.h
@@ -10,8 +10,6 @@
 
 extern void sendNoOpCommand();
 
-extern volatile void *bcm2835;
-
 typedef struct GPIORegisterFile
 {
   uint32_t gpfsel[6], reserved0; // GPIO Function Select registers, 3 bits per pin, 10 pins in an uint32_t

--- a/spi_user.h
+++ b/spi_user.h
@@ -255,7 +255,6 @@ void ExecuteSPITasks(void);
 void RunSPITask(SPITask *task);
 SPITask *GetTask(void);
 void DoneTask(SPITask *task);
-void DumpSPICS(uint32_t reg);
 #ifdef RUN_WITH_REALTIME_THREAD_PRIORITY
 void SetRealtimeThreadPriority();
 #endif

--- a/spi_user.h
+++ b/spi_user.h
@@ -5,7 +5,6 @@
 #include <sys/syscall.h>
 #include "dma.h"
 #include "spi.h"
-#include "display.h"
 #include "tick.h"
 #include "display.h"
 


### PR DESCRIPTION
Rpi 3. waveshare 3.5 tft
I get errors during installation

`
 cmake -DSPI_BUS_CLOCK_DIVISOR=16 -DWAVESHARE35B_ILI9486=ON ..
-- The C compiler identification is GNU 8.3.0
-- The CXX compiler identification is GNU 8.3.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Doing a Release build
-- Board revision: a22082
-- Detected this Pi to be one of: Pi 2B rev. 1.2, 3B, 3B+, CM3 or CM3 lite, with 4 hardware cores and ARMv8-A instruction set CPU.
-- Enabling optimization flags that target ARMv8-A instruction set (Pi 2B >= rev. 1.2, 3B, 3B+, CM3 or CM3 lite)
-- Scaling source image to view. If the HDMI resolution does not match the SPI display resolution, this will produce blurriness. Match the HDMI display resolution with the SPI resolution in /boot/config.txt to get crisp pixel perfect rendering, or alternatively pass -DDISPLAY_CROPPED_INSTEAD_OF_SCALING=ON to crop instead of scale if you want to view the center of the screen pixel perfect when HDMI and SPI resolutions do not match.
-- Preserving aspect ratio when scaling source image to the SPI display, introducing letterboxing/pillarboxing if HDMI and SPI aspect ratios are different (Pass -DDISPLAY_BREAK_ASPECT_RATIO_WHEN_SCALING=ON to stretch HDMI to cover full screen if you do not care about aspect ratio)
-- SPI_BUS_CLOCK_DIVISOR set to 16. Try setting this to a higher value (must be an even number) if this causes problems. Display update speed = core_freq/divisor. (on Pi3B, by default core_freq=400). A safe starting default value may be -DSPI_BUS_CLOCK_DIVISOR=40
-- USE_DMA_TRANSFERS enabled, this improves performance. Try running CMake with -DUSE_DMA_TRANSFERS=OFF it this causes problems, or try adjusting the DMA channels to use with -DDMA_TX_CHANNEL=<num> -DDMA_RX_CHANNEL=<num>.
-- Targeting WaveShare 3.5 inch (B) display with ILI9486
-- Configuring done
-- Generating done
-- Build files have been written to: /home/pi/fbcp-ili9341/build


pi@raspberrypi:~/fbcp-ili9341/build $ make -j
Scanning dependencies of target fbcp-ili9341
[  5%] Building CXX object CMakeFiles/fbcp-ili9341.dir/display.cpp.o
[ 10%] Building CXX object CMakeFiles/fbcp-ili9341.dir/hx8357d.cpp.o
[ 15%] Building CXX object CMakeFiles/fbcp-ili9341.dir/diff.cpp.o
[ 20%] Building CXX object CMakeFiles/fbcp-ili9341.dir/dma.cpp.o
[ 25%] Building CXX object CMakeFiles/fbcp-ili9341.dir/ili9486.cpp.o
[ 30%] Building CXX object CMakeFiles/fbcp-ili9341.dir/XPT2046.cpp.o
[ 35%] Building CXX object CMakeFiles/fbcp-ili9341.dir/gpu.cpp.o
[ 40%] Building CXX object CMakeFiles/fbcp-ili9341.dir/fbcp-ili9341.cpp.o
[ 45%] Building CXX object CMakeFiles/fbcp-ili9341.dir/ili9341.cpp.o
[ 55%] Building CXX object CMakeFiles/fbcp-ili9341.dir/mem_alloc.cpp.o
[ 60%] Building CXX object CMakeFiles/fbcp-ili9341.dir/keyboard.cpp.o
[ 55%] Building CXX object CMakeFiles/fbcp-ili9341.dir/mailbox.cpp.o
[ 65%] Building CXX object CMakeFiles/fbcp-ili9341.dir/mpi3501.cpp.o
[ 70%] Building CXX object CMakeFiles/fbcp-ili9341.dir/mz61581.cpp.o
[ 75%] Building CXX object CMakeFiles/fbcp-ili9341.dir/spi.cpp.o
[ 80%] Building CXX object CMakeFiles/fbcp-ili9341.dir/ssd1351.cpp.o
/home/pi/fbcp-ili9341/dma.cpp:129: warning: "VIRT_TO_BUS" redefined
 #define VIRT_TO_BUS(block, x) ((uintptr_t)(x) - (uintptr_t)((block).virtualAddr) + (block).busAddress)

In file included from /home/pi/fbcp-ili9341/dma.cpp:8:
/home/pi/fbcp-ili9341/spi_kernel.h:7: note: this is the location of the previous definition
 #define VIRT_TO_BUS(ptr) ((uintptr_t)(ptr) | 0xC0000000U)

[ 85%] Building CXX object CMakeFiles/fbcp-ili9341.dir/st7735r.cpp.o
[ 90%] Building CXX object CMakeFiles/fbcp-ili9341.dir/statistics.cpp.o
[ 95%] Building CXX object CMakeFiles/fbcp-ili9341.dir/text.cpp.o
In file included from /home/pi/fbcp-ili9341/spi_kernel.h:3,
                 from /home/pi/fbcp-ili9341/dma.cpp:8:
/home/pi/fbcp-ili9341/spi.h:50:12: error: ‘DMAControlBlock’ does not name a type
   volatile DMAControlBlock cb[2];
            ^~~~~~~~~~~~~~~
/home/pi/fbcp-ili9341/dma.cpp: In function ‘int InitDMA()’:
/home/pi/fbcp-ili9341/dma.cpp:218:56: error: ‘bcm2835’ was not declared in this scope
   dma0 = (volatile DMAChannelRegisterFile*)((uintptr_t)bcm2835 + BCM2835_DMA0_OFFSET);
                                                        ^~~~~~~
/home/pi/fbcp-ili9341/dma.cpp:243:47: error: ‘SHARED_MEMORY_SIZE’ was not declared in this scope
   dmaSourceBuffer = AllocateUncachedGpuMemory(SHARED_MEMORY_SIZE*2, "DMA source data");
                                               ^~~~~~~~~~~~~~~~~~
/home/pi/fbcp-ili9341/dma.cpp: In function ‘void DumpDMAState()’:
/home/pi/fbcp-ili9341/dma.cpp:352:13: error: ‘spi’ was not declared in this scope
   DumpSPICS(spi->cs);
             ^~~
/home/pi/fbcp-ili9341/dma.cpp:352:3: error: ‘DumpSPICS’ was not declared in this scope
   DumpSPICS(spi->cs);
   ^~~~~~~~~
/home/pi/fbcp-ili9341/dma.cpp:352:3: note: suggested alternative: ‘DumpCS’
   DumpSPICS(spi->cs);
   ^~~~~~~~~
   DumpCS
/home/pi/fbcp-ili9341/dma.cpp: In function ‘void WaitForDMAFinished()’:
/home/pi/fbcp-ili9341/dma.cpp:375:17: error: ‘tick’ was not declared in this scope
   uint64_t t0 = tick();
                 ^~~~
/home/pi/fbcp-ili9341/dma.cpp:378:5: error: ‘usleep’ was not declared in this scope
     usleep(100);
     ^~~~~~
/home/pi/fbcp-ili9341/dma.cpp:378:5: note: suggested alternative: ‘fseek’
     usleep(100);
     ^~~~~~
     fseek
/home/pi/fbcp-ili9341/dma.cpp:390:5: error: ‘usleep’ was not declared in this scope
     usleep(100);
     ^~~~~~
/home/pi/fbcp-ili9341/dma.cpp:390:5: note: suggested alternative: ‘fseek’
     usleep(100);
     ^~~~~~
     fseek
/home/pi/fbcp-ili9341/dma.cpp: In function ‘void SPIDMATransfer(SPITask*)’:
/home/pi/fbcp-ili9341/dma.cpp:677:3: error: ‘spi’ was not declared in this scope
   spi->cs = BCM2835_SPI0_CS_DMAEN | BCM2835_SPI0_CS_CLEAR | DISPLAY_SPI_DRIVE_SETTINGS;
   ^~~
/home/pi/fbcp-ili9341/dma.cpp:677:61: error: ‘DISPLAY_SPI_DRIVE_SETTINGS’ was not declared in this scope
   spi->cs = BCM2835_SPI0_CS_DMAEN | BCM2835_SPI0_CS_CLEAR | DISPLAY_SPI_DRIVE_SETTINGS;
                                                             ^~~~~~~~~~~~~~~~~~~~~~~~~~
/home/pi/fbcp-ili9341/dma.cpp:678:30: error: invalid use of incomplete type ‘SPITask’ {aka ‘struct SPITask’}
   uint32_t *headerAddr = task->DmaSpiHeaderAddress();
                              ^~
In file included from /home/pi/fbcp-ili9341/dma.cpp:14:
/home/pi/fbcp-ili9341/dma.h:133:16: note: forward declaration of ‘SPITask’ {aka ‘struct SPITask’}
 typedef struct SPITask SPITask;
                ^~~~~~~
/home/pi/fbcp-ili9341/dma.cpp:679:72: error: invalid use of incomplete type ‘SPITask’ {aka ‘struct SPITask’}
   *headerAddr = BCM2835_SPI0_CS_TA | DISPLAY_SPI_DRIVE_SETTINGS | (task->PayloadSize() << 16); // The first four bytes written to the SPI data register control the DLEN and CS,CPOL,CPHA settings.
                                                                        ^~
In file included from /home/pi/fbcp-ili9341/dma.cpp:14:
/home/pi/fbcp-ili9341/dma.h:133:16: note: forward declaration of ‘SPITask’ {aka ‘struct SPITask’}
 typedef struct SPITask SPITask;
                ^~~~~~~
/home/pi/fbcp-ili9341/dma.cpp:685:55: error: invalid use of incomplete type ‘SPITask’ {aka ‘struct SPITask’}
   memcpy(dmaSourceBuffer.virtualAddr, headerAddr, task->PayloadSize() + 4);
                                                       ^~
In file included from /home/pi/fbcp-ili9341/dma.cpp:14:
/home/pi/fbcp-ili9341/dma.h:133:16: note: forward declaration of ‘SPITask’ {aka ‘struct SPITask’}
 typedef struct SPITask SPITask;
                ^~~~~~~
/home/pi/fbcp-ili9341/dma.cpp:692:19: error: invalid use of incomplete type ‘SPITask’ {aka ‘struct SPITask’}
   txcb->len = task->PayloadSize() + 4;
                   ^~
In file included from /home/pi/fbcp-ili9341/dma.cpp:14:
/home/pi/fbcp-ili9341/dma.h:133:16: note: forward declaration of ‘SPITask’ {aka ‘struct SPITask’}
 typedef struct SPITask SPITask;
                ^~~~~~~
/home/pi/fbcp-ili9341/dma.cpp:703:19: error: invalid use of incomplete type ‘SPITask’ {aka ‘struct SPITask’}
   rxcb->len = task->PayloadSize();
                   ^~
In file included from /home/pi/fbcp-ili9341/dma.cpp:14:
/home/pi/fbcp-ili9341/dma.h:133:16: note: forward declaration of ‘SPITask’ {aka ‘struct SPITask’}
 typedef struct SPITask SPITask;
                ^~~~~~~
/home/pi/fbcp-ili9341/dma.cpp:715:33: error: invalid use of incomplete type ‘SPITask’ {aka ‘struct SPITask’}
   double pendingTaskUSecs = task->PayloadSize() * spiUsecsPerByte;
                                 ^~
In file included from /home/pi/fbcp-ili9341/dma.cpp:14:
/home/pi/fbcp-ili9341/dma.h:133:16: note: forward declaration of ‘SPITask’ {aka ‘struct SPITask’}
 typedef struct SPITask SPITask;
                ^~~~~~~
/home/pi/fbcp-ili9341/dma.cpp:717:5: error: ‘usleep’ was not declared in this scope
     usleep(pendingTaskUSecs-70);
     ^~~~~~
/home/pi/fbcp-ili9341/dma.cpp:717:5: note: suggested alternative: ‘fseek’
     usleep(pendingTaskUSecs-70);
     ^~~~~~
     fseek
/home/pi/fbcp-ili9341/dma.cpp:719:27: error: ‘tick’ was not declared in this scope
   uint64_t dmaTaskStart = tick();
                           ^~~~
/home/pi/fbcp-ili9341/dma.cpp:719:27: note: suggested alternative: ‘txcb’
   uint64_t dmaTaskStart = tick();
                           ^~~~
                           txcb
make[2]: *** [CMakeFiles/fbcp-ili9341.dir/build.make:102: CMakeFiles/fbcp-ili9341.dir/dma.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
/home/pi/fbcp-ili9341/spi.cpp: In function ‘void sendNoOpCommand()’:
/home/pi/fbcp-ili9341/spi.cpp:285:15: error: ‘DISPLAY_NO_OPERATION’ was not declared in this scope
   task->cmd = DISPLAY_NO_OPERATION;
               ^~~~~~~~~~~~~~~~~~~~
/home/pi/fbcp-ili9341/spi.cpp:285:15: note: suggested alternative: ‘DISPLAY_DITHER_T’
   task->cmd = DISPLAY_NO_OPERATION;
               ^~~~~~~~~~~~~~~~~~~~
               DISPLAY_DITHER_T
/home/pi/fbcp-ili9341/spi.cpp: In function ‘void* spi_thread(void*)’:
/home/pi/fbcp-ili9341/spi.cpp:515:1: warning: no return statement in function returning non-void [-Wreturn-type]
 }
 ^
make[2]: *** [CMakeFiles/fbcp-ili9341.dir/build.make:245: CMakeFiles/fbcp-ili9341.dir/spi.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:73: CMakeFiles/fbcp-ili9341.dir/all] Error 2
make: *** [Makefile:84: all] Error 2
`